### PR TITLE
remove html forms inside view selection

### DIFF
--- a/src/main/java/org/quantil/camunda/plugin/services/ProcessViewService.java
+++ b/src/main/java/org/quantil/camunda/plugin/services/ProcessViewService.java
@@ -73,9 +73,11 @@ public class ProcessViewService {
 
         // order list to get next view in the row
         List<String> orderedResources = new ArrayList<>();
-
         // add BPMN file as initial view and sort remaining views using the resource names
         List<String> resourceNames = new ArrayList<>(resources.values());
+
+        // remove html forms 
+        resourceNames.removeIf(resourceName -> resourceName.endsWith(".html"));
         String initialView =
                 resourceNames.stream().filter(resourceName -> resourceName.endsWith(".bpmn")).findFirst().orElseThrow(NoSuchElementException::new);
         orderedResources.add(initialView);


### PR DESCRIPTION
Since html forms are part of the deployment resources, we need to remove them when we select a view.